### PR TITLE
Add ephemeral response_type to the Slack connector InteractiveAction respond method

### DIFF
--- a/opsdroid/connector/slack/events.py
+++ b/opsdroid/connector/slack/events.py
@@ -69,8 +69,9 @@ class InteractiveAction(events.Event):
         self.payload = payload
         self.ssl_context = ssl.create_default_context(cafile=certifi.where())
 
-    async def respond(self, response_event):
+    async def respond(self, response_event, **kwargs):
         """Respond to this message using the response_url field in the payload."""
+        response_type = kwargs.get("response_type", "in_channel")
 
         if isinstance(response_event, str):
             if "response_url" in self.payload:
@@ -83,7 +84,7 @@ class InteractiveAction(events.Event):
                                 "text": response_event,
                                 "replace_original": False,
                                 "delete_original": False,
-                                "response_type": "in_channel",
+                                "response_type": response_type,
                             }
                         ),
                         headers=headers,


### PR DESCRIPTION
# Description

This is not a complete fix. It seems to work only in the case where we are responding to an `InteractiveAction` for the Slack connector where the message being sent is a string. It would be much better if we were able to specify an ephemeral `response_type`, whether a string or Blocks or anything else. 👈  I'm not sure how to accomplish this and would appreciate some help. Once we can get this working for a response, then I think we can do it easily for an original message as well.

The ability to send ephemeral messages is a key part of building an interactive Slack app as it allows a single user to have great interactivity prior to taking an action that would result in posting a message to a channel. This allows you to write entire UI interfaces in Slack, which is quite an expansion from just a chatbot.

Here's what I've been able to accomplish so far.

- Added in `kwargs` to the `respond` method
- Set `response_type` variable based on `kwarg` with same name
- Set `response_type` based on value passed in for the case where `response_event` is a `str`

## Status
**UNDER DEVELOPMENT**

## Type of change

<!-- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I will need help writing tests for this.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
