### PR TITLE
Add in capability to supply `user` and `password` with mongodb

### DIFF
--- a/docs/databases/mongo.md
+++ b/docs/databases/mongo.md
@@ -11,9 +11,11 @@ None.
 ```yaml
 databases:
   mongo:
-    host:       "my host"     # (optional) default "localhost"
+    host:       "my_host"     # (optional) default "localhost"
     port:       "12345"       # (optional) default "27017"
-    database:   "mydatabase"  # (optional) default "opsdroid"
+    database:   "my_database" # (optional) default "opsdroid"
+    user:       "my_user"     # (optional) default "root"
+    password:   "pwd123!"     # (optional) default "mongo"
 ```
 
 ## Usage

--- a/docs/databases/mongo.md
+++ b/docs/databases/mongo.md
@@ -14,8 +14,8 @@ databases:
     host:       "my_host"     # (optional) default "localhost"
     port:       "12345"       # (optional) default "27017"
     database:   "my_database" # (optional) default "opsdroid"
-    user:       "my_user"     # (optional) default "root"
-    password:   "pwd123!"     # (optional) default "mongo"
+    user:       "my_user"     # (optional)
+    password:   "pwd123!"     # (optional)
 ```
 
 ## Usage

--- a/opsdroid/database/mongo/__init__.py
+++ b/opsdroid/database/mongo/__init__.py
@@ -37,7 +37,12 @@ class DatabaseMongo(Database):
         host = self.config.get("host", "localhost")
         port = self.config.get("port", "27017")
         database = self.config.get("database", "opsdroid")
-        path = "mongodb://{host}:{port}".format(host=host, port=port)
+        user = self.config.get("user", "root")
+        pwd = self.config.get("password", "mongo")
+        if user and pwd:
+            path = "mongodb://{user}:{pwd}@{host}:{port}".format(user=user, pwd=pwd, host=host, port=port)
+        else:
+            path = "mongodb://{host}:{port}".format(host=host, port=port)
         self.client = AsyncIOMotorClient(path)
         self.database = self.client[database]
         _LOGGER.info("Connected to MongoDB.")

--- a/opsdroid/database/mongo/__init__.py
+++ b/opsdroid/database/mongo/__init__.py
@@ -37,8 +37,8 @@ class DatabaseMongo(Database):
         host = self.config.get("host", "localhost")
         port = self.config.get("port", "27017")
         database = self.config.get("database", "opsdroid")
-        user = self.config.get("user", "root")
-        pwd = self.config.get("password", "mongo")
+        user = self.config.get("user")
+        pwd = self.config.get("password")
         if user and pwd:
             path = "mongodb://{user}:{pwd}@{host}:{port}".format(user=user, pwd=pwd, host=host, port=port)
         else:

--- a/opsdroid/database/mongo/tests/test_mongo.py
+++ b/opsdroid/database/mongo/tests/test_mongo.py
@@ -9,7 +9,13 @@ def database(config):
     return DatabaseMongo(config)
 
 
-@pytest.mark.parametrize("config", [{"database": "test_db"}])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"database": "test_db"},
+        {"database": "test_db", "user": "root", "password": "mongo"},
+    ]
+)
 def test_init(database):
     """Test that the database is initialised properly."""
     assert database.name == "mongo"


### PR DESCRIPTION
# Description

Some mongodb environments require `user` and `password` to be supplied in order to properly connect. This change allows this while not breaking current functionality where this does not need to be provided.

Add documentation to support `user` and `password` functionality for mongodb.

## Status
**READY**


## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation (fix or adds documentation)


# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- Manually connected to mongodb that required user/password to be set _without_ the params set up in my configuration file to make sure that failed.
- Manually connected to mongodb that required user/password to be set _with_ the params set up in my configuration file to make sure that failed.
- Ran existing tests to make sure current connect functionality still ran.
- Added a new test that passed in `user` and `password` when initializing the database


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
